### PR TITLE
🧪 Add testing improvement for empty TOML config

### DIFF
--- a/spec/mzap_config_parsing_spec.cr
+++ b/spec/mzap_config_parsing_spec.cr
@@ -45,6 +45,25 @@ describe Mzap::Config do
     end
   end
 
+  it "returns empty FileOptions without errors for an empty TOML config" do
+    with_temp_home do |temp_home|
+      config_path = File.join(temp_home, ".config", "mzap", "config.toml")
+      Dir.mkdir_p(File.dirname(config_path))
+      File.write(config_path, "")
+
+      loaded = Mzap::Config.load_options("")
+      loaded.path.should eq(config_path)
+      loaded.apis.should be_nil
+      loaded.api_key.should be_nil
+      loaded.urls.should be_nil
+      loaded.wait.should be_nil
+      loaded.wait_interval_seconds.should be_nil
+      loaded.wait_timeout_seconds.should be_nil
+      loaded.report_format.should be_nil
+      loaded.report_out.should be_nil
+    end
+  end
+
   it "loads root-level keys and ignores unrelated tables" do
     with_temp_home do |temp_home|
       config_path = File.join(temp_home, ".config", "mzap", "config.toml")


### PR DESCRIPTION
🎯 **What:** Added an edge case test in `spec/mzap_config_parsing_spec.cr` for parsing an empty TOML configuration file.
📊 **Coverage:** The test covers the scenario where the TOML config file is empty, ensuring that `Mzap::Config.load_options` correctly returns a `FileOptions` object with all attributes safely set to `nil` rather than raising an error.
✨ **Result:** Improved test coverage and reliability for TOML parsing by verifying robust handling of empty configuration files.

---
*PR created automatically by Jules for task [13589559884258131392](https://jules.google.com/task/13589559884258131392) started by @hahwul*