### PR TITLE
🧪 test: add coverage for Mzap module wrapper methods

### DIFF
--- a/spec/mzap_spec.cr
+++ b/spec/mzap_spec.cr
@@ -1,0 +1,95 @@
+require "./spec_helper"
+
+describe Mzap do
+  describe "module wrapper methods" do
+    it "delegates spider to Mzap::Client" do
+      server = TestServer.new
+      begin
+        reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
+        with_target_file(["https://target.test"]) do |target_file|
+          options = Mzap::Options.new("key", target_file)
+          Mzap.spider(target_file, server.url, options, reporter)
+        end
+        requests = server.requests
+        requests.size.should be > 0
+        requests.map(&.path).includes?(Mzap::Client::SPIDER_API).should be_true
+      ensure
+        server.close
+      end
+    end
+
+    it "delegates ajax_spider to Mzap::Client" do
+      server = TestServer.new
+      begin
+        reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
+        with_target_file(["https://target.test"]) do |target_file|
+          options = Mzap::Options.new("key", target_file)
+          Mzap.ajax_spider(target_file, server.url, options, reporter)
+        end
+        requests = server.requests
+        requests.size.should be > 0
+        requests.map(&.path).includes?(Mzap::Client::AJAX_SPIDER_API).should be_true
+      ensure
+        server.close
+      end
+    end
+
+    it "delegates active_scan to Mzap::Client" do
+      server = TestServer.new
+      begin
+        reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
+        with_target_file(["https://target.test"]) do |target_file|
+          options = Mzap::Options.new("key", target_file)
+          Mzap.active_scan(target_file, server.url, options, reporter)
+        end
+        requests = server.requests
+        requests.size.should be > 0
+        requests.map(&.path).includes?(Mzap::Client::ASCAN_API).should be_true
+      ensure
+        server.close
+      end
+    end
+
+    it "delegates stop_spider to Mzap::Client" do
+      server = TestServer.new
+      begin
+        reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
+        options = Mzap::Options.new("key", "")
+        Mzap.stop_spider(server.url, options, reporter)
+        requests = server.requests
+        requests.size.should be > 0
+        requests.map(&.path).includes?(stop_path(Mzap::Client::SPIDER_STOP)).should be_true
+      ensure
+        server.close
+      end
+    end
+
+    it "delegates stop_active_scan to Mzap::Client" do
+      server = TestServer.new
+      begin
+        reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
+        options = Mzap::Options.new("key", "")
+        Mzap.stop_active_scan(server.url, options, reporter)
+        requests = server.requests
+        requests.size.should be > 0
+        requests.map(&.path).includes?(stop_path(Mzap::Client::ASCAN_STOP)).should be_true
+      ensure
+        server.close
+      end
+    end
+
+    it "delegates stop_ajax_spider to Mzap::Client" do
+      server = TestServer.new
+      begin
+        reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
+        options = Mzap::Options.new("key", "")
+        Mzap.stop_ajax_spider(server.url, options, reporter)
+        requests = server.requests
+        requests.size.should be > 0
+        requests.map(&.path).includes?(stop_path(Mzap::Client::AJAX_SPIDER_STOP)).should be_true
+      ensure
+        server.close
+      end
+    end
+  end
+end


### PR DESCRIPTION
🎯 **What:** The testing gap for module `Mzap` wrapper methods was addressed. The methods (`spider`, `ajax_spider`, `active_scan`, `stop_spider`, `stop_active_scan`, and `stop_ajax_spider`) in `src/mzap.cr` previously lacked dedicated unit tests.
📊 **Coverage:** The tests verify the happy path where calling each of these module methods properly delegates the call to the underlying `Mzap::Client` by asserting that the relevant API endpoints on a mock `TestServer` are hit.
✨ **Result:** Test coverage is improved, ensuring regressions to these simple but critical delegation wrappers are caught during testing. All tests pass successfully (169 examples).

---
*PR created automatically by Jules for task [16950584407819002430](https://jules.google.com/task/16950584407819002430) started by @hahwul*