### PR TITLE
🧪 Add test for gracefully handling JSON::ParseException

### DIFF
--- a/spec/mzap_client_wait_spec.cr
+++ b/spec/mzap_client_wait_spec.cr
@@ -720,4 +720,38 @@ describe Mzap do
       end
     end
   end
+
+  it "gracefully handles JSON::ParseException in extract_json_value" do
+    server = TestServer.new(->(context : HTTP::Server::Context) do
+      case context.request.path
+      when Mzap::Client::ACCESS_API
+        context.response.status_code = 200
+        context.response.print(%({"ok":"true"}))
+      when Mzap::Client::SPIDER_API
+        context.response.status_code = 200
+        context.response.print(%({"scan":"1"}))
+      when Mzap::Client::SPIDER_STATUS
+        context.response.status_code = 200
+        context.response.print("invalid json string {]}")
+      else
+        context.response.status_code = 404
+        context.response.print("not found")
+      end
+    end)
+
+    begin
+      stdout_io = IO::Memory.new
+      stderr_io = IO::Memory.new
+      reporter = Mzap::Reporter.new(stdout_io, stderr_io)
+      with_target_file(["https://json-error.test"]) do |target_file|
+        options = Mzap::Options.new("", target_file, true, 0, 1)
+        Mzap.spider(target_file, server.url, options, reporter)
+      end
+
+      stderr = stderr_io.to_s
+      stderr.includes?("status check failed (missing status value)").should be_true
+    ensure
+      server.close
+    end
+  end
 end


### PR DESCRIPTION
🎯 **What:** Added a missing test case in `spec/mzap_client_wait_spec.cr` for when `extract_json_value` encounters invalid JSON and raises `JSON::ParseException`.
📊 **Coverage:** The test simulates an API returning completely broken JSON from the `SPIDER_STATUS` endpoint.
✨ **Result:** Verifies that `extract_json_value` safely catches `JSON::ParseException`, returns `nil`, and allows the wait polling logic to log the failure and continue gracefully without crashing the application.

---
*PR created automatically by Jules for task [3717536237813682213](https://jules.google.com/task/3717536237813682213) started by @hahwul*