### PR TITLE
🧪 [Testing] Cover unexpected exception fallback path in CLI run

### DIFF
--- a/spec/mzap_cli_commands_spec.cr
+++ b/spec/mzap_cli_commands_spec.cr
@@ -599,4 +599,14 @@ describe Mzap::CLI do
       server.close
     end
   end
+
+  it "rescues unexpected exceptions during execution and returns 1" do
+    stdout_io = RaisingIO.new
+    stderr_io = IO::Memory.new
+
+    code = Mzap::CLI.run(["version"], stdout_io, stderr_io)
+
+    code.should eq(1)
+    stderr_io.to_s.includes?("Mocked unexpected Exception").should be_true
+  end
 end

--- a/spec/support/test_helpers.cr
+++ b/spec/support/test_helpers.cr
@@ -87,3 +87,13 @@ def sanitized_host_for_report(value : String) : String
   normalized = value.gsub(/[^a-zA-Z0-9]+/, "-").gsub(/^-+/, "").gsub(/-+$/, "")
   normalized.empty? ? "host" : normalized
 end
+
+class RaisingIO < IO
+  def read(slice : Bytes) : Int32
+    0
+  end
+
+  def write(slice : Bytes) : Nil
+    raise Exception.new("Mocked unexpected Exception")
+  end
+end


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
This PR addresses the missing error path test for unexpected exceptions that can happen during the CLI run loop, which was not covered in `mzap_cli_commands_spec.cr`.

📊 **Coverage:** What scenarios are now tested
A new test guarantees that any unexpected `Exception` raised deep within the `run` method is gracefully caught by the `rescue ex` block, prints the exact error message to stderr, and correctly forces an exit status of 1.

✨ **Result:** The improvement in test coverage
We now have absolute confidence that the `rescue ex` block at the bottom of the CLI execution performs its fallback safety duties accurately and returns the expected status code.

---
*PR created automatically by Jules for task [633434547347411516](https://jules.google.com/task/633434547347411516) started by @hahwul*