### PR TITLE
Add Snapcraft package and publish workflow

### DIFF
--- a/.github/workflows/publish-snapcraft.yml
+++ b/.github/workflows/publish-snapcraft.yml
@@ -1,0 +1,34 @@
+---
+name: Snapcraft Publish
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: Log level
+        required: true
+        default: warning
+      tags:
+        description: Test scenario tags
+jobs:
+  snapcraft-releaser:
+    runs-on: ubuntu-latest
+    name: snapcraft-releaser
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - amd64
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v6
+      - uses: canonical/action-build@v1
+        id: build
+      - if: github.event_name == 'release'
+        uses: snapcore/action-publish@master
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: stable

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,45 @@
+name: mzap
+base: core24
+version: 2.0.0
+summary: Multi-target ZAP scanning CLI tool with multi-host dispatch and report generation
+description: |
+  mzap is a multi-target ZAP scanning CLI tool with multi-host dispatch
+  and report generation. It enables efficient parallel scanning across
+  multiple ZAP instances for large-scale web application security testing.
+
+grade: stable
+confinement: strict
+license: MIT
+
+apps:
+  mzap:
+    command: mzap
+    plugs:
+      - home
+      - network
+      - network-bind
+
+parts:
+  mzap:
+    source: ./
+    plugin: nil
+    override-build: |
+      curl -fsSL https://crystal-lang.org/install.sh | bash
+      shards install --production
+      shards build --release --no-debug --production
+      cp ./bin/mzap $CRAFT_PART_INSTALL/
+    build-packages:
+      - git
+      - curl
+      - pkg-config
+      - libssl-dev
+      - libxml2-dev
+      - libz-dev
+      - libyaml-dev
+      - libpcre2-dev
+      - libevent-dev
+      - libgmp-dev
+    stage-packages:
+      - libxml2
+      - zlib1g
+      - libyaml-0-2


### PR DESCRIPTION
## Summary
- 2.0 마이그레이션에서 누락된 Snap 패키지 배포를 복구합니다
- `snap/snapcraft.yaml`: core24 기반 strict confinement 스냅 패키지 설정
- `.github/workflows/publish-snapcraft.yml`: release 발행 시 Snap Store에 자동 배포하는 워크플로우

## Test plan
- [x] `snapcraft` 로컬 빌드 테스트
- [x] workflow_dispatch로 수동 트리거 테스트
- [x] `SNAP_STORE_LOGIN` 시크릿 등록 확인