### PR TITLE
Improve Options struct and enforce named arguments

### DIFF
--- a/spec/mzap_client_report_spec.cr
+++ b/spec/mzap_client_report_spec.cr
@@ -32,8 +32,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["https://report.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 1, 10, "html", report_path)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 1, wait_timeout_seconds: 10, report_format: "html", report_out: report_path)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       requests = server.requests
@@ -84,8 +84,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://fallback.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 1, 10, "html", report_path)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 1, wait_timeout_seconds: 10, report_format: "html", report_out: report_path)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       requests = server.requests
@@ -132,8 +132,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://report-fail.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 1, 10, "html", report_path)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 1, wait_timeout_seconds: 10, report_format: "html", report_out: report_path)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       stderr = stderr_io.to_s
@@ -221,8 +221,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://saved.test", "https://fallback.test", "https://failed.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5, "html", report_path)
-        Mzap.spider(target_file, "#{saved_server.url},#{fallback_server.url},#{failed_server.url}", options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5, report_format: "html", report_out: report_path)
+        Mzap.spider(target_file, apis: "#{saved_server.url},#{fallback_server.url},#{failed_server.url}", options: options, reporter: reporter)
       end
 
       stdout = stdout_io.to_s
@@ -275,8 +275,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["https://ext.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 1, 10, "pdf", report_path)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 1, wait_timeout_seconds: 10, report_format: "pdf", report_out: report_path)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       report_request = server.requests.find { |request| request.path == Mzap::Client::REPORT_GENERATE_API }
@@ -320,8 +320,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["https://one.test", "https://two.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 1, 10, "pdf", report_path)
-        Mzap.spider(target_file, "#{server1.url},#{server2.url}", options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 1, wait_timeout_seconds: 10, report_format: "pdf", report_out: report_path)
+        Mzap.spider(target_file, apis: "#{server1.url},#{server2.url}", options: options, reporter: reporter)
       end
 
       full_path = File.expand_path(report_path)
@@ -377,8 +377,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["https://collision-one.test", "https://collision-two.test", "https://collision-three.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5, "html", "collision-report")
-        Mzap.spider(target_file, "#{server1.url},#{server2.url},#{server3.url}", options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5, report_format: "html", report_out: "collision-report")
+        Mzap.spider(target_file, apis: "#{server1.url},#{server2.url},#{server3.url}", options: options, reporter: reporter)
       end
 
       all_requests = server1.requests + server2.requests + server3.requests
@@ -430,8 +430,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["https://default-report.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, false, 0, 5, "html", "")
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_interval_seconds: 0, wait_timeout_seconds: 5, report_format: "html")
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       report_request = server.requests.find { |request| request.path == Mzap::Client::REPORT_GENERATE_API }
@@ -473,8 +473,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["https://one.test", "https://two.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5, "pdf", "scan-report")
-        Mzap.spider(target_file, "#{server1.url},#{server2.url}", options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5, report_format: "pdf", report_out: "scan-report")
+        Mzap.spider(target_file, apis: "#{server1.url},#{server2.url}", options: options, reporter: reporter)
       end
 
       expected1 = "scan-report-#{sanitized_host_for_report(server1.url)}.pdf"
@@ -522,8 +522,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["https://dup.test", "https://dup.test", "https://unique.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5, "html", "")
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5, report_format: "html")
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       report_request = server.requests.find { |request| request.path == Mzap::Client::REPORT_GENERATE_API }
@@ -565,8 +565,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://pdf-fallback.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5, "pdf", report_path)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5, report_format: "pdf", report_out: report_path)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       paths = server.requests.map(&.path)
@@ -606,8 +606,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["https://ext-case.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5, "html", report_path)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5, report_format: "html", report_out: report_path)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       report_request = server.requests.find { |request| request.path == Mzap::Client::REPORT_GENERATE_API }
@@ -651,8 +651,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://report-path-error.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5, "html", report_path)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5, report_format: "html", report_out: report_path)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       stderr = stderr_io.to_s
@@ -697,8 +697,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://nested-fallback.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5, "html", report_path)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5, report_format: "html", report_out: report_path)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       File.exists?(report_path).should be_true
@@ -746,8 +746,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://core-report-path-error.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5, "html", blocking_dir_with_ext)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5, report_format: "html", report_out: blocking_dir_with_ext)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       stderr = stderr_io.to_s

--- a/spec/mzap_client_scan_spec.cr
+++ b/spec/mzap_client_scan_spec.cr
@@ -8,8 +8,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["https://a.test", "https://b.test", "https://c.test"]) do |target_file|
-        options = Mzap::Options.new("test-key", target_file)
-        Mzap.spider(target_file, "#{server1.url},#{server2.url}", options, reporter)
+        options = Mzap::Options.new(api_key: "test-key")
+        Mzap.spider(target_file, apis: "#{server1.url},#{server2.url}", options: options, reporter: reporter)
       end
 
       requests1 = server1.requests
@@ -48,8 +48,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["https://ajax.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file)
-        Mzap.ajax_spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new
+        Mzap.ajax_spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       requests = server.requests
@@ -67,8 +67,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["https://ascan.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file)
-        Mzap.active_scan(target_file, server.url, options, reporter)
+        options = Mzap::Options.new
+        Mzap.active_scan(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       requests = server.requests
@@ -87,8 +87,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["  https://a.test  ", "", "   # comment", "https://b.test", "   "]) do |target_file|
-        options = Mzap::Options.new("", target_file)
-        Mzap.spider(target_file, " #{server1.url} , #{server2.url} ", options, reporter)
+        options = Mzap::Options.new
+        Mzap.spider(target_file, apis: " #{server1.url} , #{server2.url} ", options: options, reporter: reporter)
       end
 
       requests1 = server1.requests
@@ -114,8 +114,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["", "   ", "  # comment"]) do |target_file|
-        options = Mzap::Options.new("", target_file)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       server.requests.should be_empty
@@ -141,8 +141,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://error.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       stderr_io.to_s.includes?("error (scan)").should be_true
@@ -169,8 +169,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://access-error.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       stderr_io.to_s.includes?("error (access)").should be_true
@@ -207,8 +207,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://ok.test", "https://bad.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       stdout = stdout_io.to_s
@@ -229,8 +229,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://dup.test", "https://dup.test", "https://unique.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       requests = server.requests
@@ -249,7 +249,7 @@ describe Mzap do
     stderr_io = IO::Memory.new
     reporter = Mzap::Reporter.new(stdout_io, stderr_io)
 
-    Mzap::Client.run("/tmp/definitely-nonexistent-mzap-file.txt", "http://127.0.0.1:1", "spider", Mzap::Options.new("", ""), reporter)
+    Mzap::Client.run("/tmp/definitely-nonexistent-mzap-file.txt", "http://127.0.0.1:1", "spider", Mzap::Options.new, reporter)
 
     stderr_io.to_s.includes?("target file not found").should be_true
   end
@@ -260,8 +260,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["https://trailing.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file)
-        Mzap.spider(target_file, "#{server.url}/", options, reporter)
+        options = Mzap::Options.new
+        Mzap.spider(target_file, apis: "#{server.url}/", options: options, reporter: reporter)
       end
 
       requests = server.requests
@@ -279,8 +279,8 @@ describe Mzap do
     reporter = Mzap::Reporter.new(stdout_io, stderr_io)
 
     with_target_file(["https://transport-empty.test"]) do |target_file|
-      options = Mzap::Options.new("", target_file)
-      Mzap.spider(target_file, "http://127.0.0.1:1", options, reporter)
+      options = Mzap::Options.new
+      Mzap.spider(target_file, apis: "http://127.0.0.1:1", options: options, reporter: reporter)
     end
 
     stderr = stderr_io.to_s
@@ -294,8 +294,8 @@ describe Mzap do
     reporter = Mzap::Reporter.new(stdout_io, stderr_io)
 
     with_target_file(["https://transport-fail.test"]) do |target_file|
-      options = Mzap::Options.new("", target_file)
-      Mzap.spider(target_file, "http://127.0.0.1:1", options, reporter)
+      options = Mzap::Options.new
+      Mzap.spider(target_file, apis: "http://127.0.0.1:1", options: options, reporter: reporter)
     end
 
     stderr = stderr_io.to_s

--- a/spec/mzap_client_stop_spec.cr
+++ b/spec/mzap_client_stop_spec.cr
@@ -11,8 +11,8 @@ describe Mzap do
       stdout_io = IO::Memory.new
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
-      options = Mzap::Options.new("", "")
-      Mzap.stop_spider(server.url, options, reporter)
+      options = Mzap::Options.new
+      Mzap.stop_spider(server.url, options: options, reporter: reporter)
 
       stderr_io.to_s.includes?("error (stop)").should be_true
       stderr_io.to_s.includes?("HTTP 500").should be_true
@@ -34,8 +34,8 @@ describe Mzap do
       stdout_io = IO::Memory.new
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
-      options = Mzap::Options.new("", "")
-      Mzap.stop_spider("#{server_success.url},#{server_fail.url}", options, reporter)
+      options = Mzap::Options.new
+      Mzap.stop_spider("#{server_success.url},#{server_fail.url}", options: options, reporter: reporter)
 
       stdout = stdout_io.to_s
       stderr = stderr_io.to_s
@@ -53,10 +53,10 @@ describe Mzap do
 
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
-      options = Mzap::Options.new("stop-key", "")
-      Mzap.stop_spider(server.url, options, reporter)
-      Mzap.stop_ajax_spider(server.url, options, reporter)
-      Mzap.stop_active_scan(server.url, options, reporter)
+      options = Mzap::Options.new(api_key: "stop-key")
+      Mzap.stop_spider(server.url, options: options, reporter: reporter)
+      Mzap.stop_ajax_spider(server.url, options: options, reporter: reporter)
+      Mzap.stop_active_scan(server.url, options: options, reporter: reporter)
 
       requests = server.requests
       requests.size.should eq(3)
@@ -75,9 +75,9 @@ describe Mzap do
     stdout_io = IO::Memory.new
     stderr_io = IO::Memory.new
     reporter = Mzap::Reporter.new(stdout_io, stderr_io)
-    options = Mzap::Options.new("", "")
+    options = Mzap::Options.new
 
-    Mzap.stop_spider("http://127.0.0.1:1,http://127.0.0.1:2", options, reporter)
+    Mzap.stop_spider("http://127.0.0.1:1,http://127.0.0.1:2", options: options, reporter: reporter)
 
     stderr = stderr_io.to_s
     stdout = stdout_io.to_s
@@ -95,8 +95,8 @@ describe Mzap do
       stdout_io = IO::Memory.new
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
-      options = Mzap::Options.new("", "")
-      Mzap.stop_spider(server.url, options, reporter)
+      options = Mzap::Options.new
+      Mzap.stop_spider(server.url, options: options, reporter: reporter)
 
       stdout_io.to_s.includes?("stopped").should be_true
       stderr_io.to_s.should eq("")

--- a/spec/mzap_client_wait_spec.cr
+++ b/spec/mzap_client_wait_spec.cr
@@ -24,8 +24,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://timeout.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 1, 1)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 1, wait_timeout_seconds: 1)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       stderr = stderr_io.to_s
@@ -59,8 +59,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://wait-error.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 1, 1)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 1, wait_timeout_seconds: 1)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       stderr = stderr_io.to_s
@@ -104,8 +104,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://ajax-wait.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5)
-        Mzap.ajax_spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.ajax_spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       paths = server.requests.map(&.path)
@@ -141,8 +141,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["https://scan-id.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       status_queries.size.should eq(1)
@@ -173,8 +173,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://missing-scan-id.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       paths = server.requests.map(&.path)
@@ -215,8 +215,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://missing-status.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       stderr = stderr_io.to_s
@@ -251,8 +251,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["https://numeric-id.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       status_queries.size.should eq(1)
@@ -286,8 +286,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://boolean-status.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       stdout = stdout_io.to_s
@@ -329,8 +329,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://dedupe-wait-error.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       stderr = stderr_io.to_s
@@ -366,8 +366,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["https://ascan-scanid.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5)
-        Mzap.active_scan(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.active_scan(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       status_queries.size.should eq(1)
@@ -398,8 +398,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://invalid-json-scan.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       paths = server.requests.map(&.path)
@@ -440,8 +440,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://invalid-status-json.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       stderr_io.to_s.includes?("status check failed").should be_true
@@ -474,8 +474,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://ascan-wait.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5)
-        Mzap.active_scan(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.active_scan(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       paths = server.requests.map(&.path)
@@ -516,8 +516,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://ajax-dedupe-fail.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5)
-        Mzap.ajax_spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.ajax_spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       stderr = stderr_io.to_s
@@ -553,8 +553,8 @@ describe Mzap do
     begin
       reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
       with_target_file(["https://ajax-one.test", "https://ajax-two.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5)
-        Mzap.ajax_spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.ajax_spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       ajax_status_calls.should eq(1)
@@ -592,8 +592,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://status-change.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       status_calls.should eq(2)
@@ -629,8 +629,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://float-status.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       stdout = stdout_io.to_s
@@ -664,8 +664,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://error-status.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 5)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       stderr = stderr_io.to_s
@@ -709,8 +709,8 @@ describe Mzap do
         stderr_io = IO::Memory.new
         reporter = Mzap::Reporter.new(stdout_io, stderr_io)
         with_target_file(["https://#{running_status}-status.test"]) do |target_file|
-          options = Mzap::Options.new("", target_file, true, 0, 5)
-          Mzap.spider(target_file, server.url, options, reporter)
+          options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+          Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
         end
 
         status_calls.should eq(2)
@@ -744,8 +744,8 @@ describe Mzap do
       stderr_io = IO::Memory.new
       reporter = Mzap::Reporter.new(stdout_io, stderr_io)
       with_target_file(["https://json-error.test"]) do |target_file|
-        options = Mzap::Options.new("", target_file, true, 0, 1)
-        Mzap.spider(target_file, server.url, options, reporter)
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 1)
+        Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
       end
 
       stderr = stderr_io.to_s

--- a/spec/mzap_options_spec.cr
+++ b/spec/mzap_options_spec.cr
@@ -2,19 +2,19 @@ require "./spec_helper"
 
 describe Mzap::Options do
   it "enables wait when wait_for_completion is set" do
-    options = Mzap::Options.new("", "", true, 2, 0, "", "")
+    options = Mzap::Options.new(wait_for_completion: true)
     options.wait_enabled?.should eq(true)
     options.report_enabled?.should eq(false)
   end
 
   it "enables wait automatically when report format is set" do
-    options = Mzap::Options.new("", "", false, 2, 0, "html", "")
+    options = Mzap::Options.new(report_format: "html")
     options.wait_enabled?.should eq(true)
     options.report_enabled?.should eq(true)
   end
 
   it "disables wait and report when neither flag is set" do
-    options = Mzap::Options.new("", "", false, 2, 0, "", "")
+    options = Mzap::Options.new
     options.wait_enabled?.should eq(false)
     options.report_enabled?.should eq(false)
   end

--- a/spec/mzap_spec.cr
+++ b/spec/mzap_spec.cr
@@ -7,8 +7,8 @@ describe Mzap do
       begin
         reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
         with_target_file(["https://target.test"]) do |target_file|
-          options = Mzap::Options.new("key", target_file)
-          Mzap.spider(target_file, server.url, options, reporter)
+          options = Mzap::Options.new(api_key: "key")
+          Mzap.spider(target_file, apis: server.url, options: options, reporter: reporter)
         end
         requests = server.requests
         requests.size.should be > 0
@@ -23,8 +23,8 @@ describe Mzap do
       begin
         reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
         with_target_file(["https://target.test"]) do |target_file|
-          options = Mzap::Options.new("key", target_file)
-          Mzap.ajax_spider(target_file, server.url, options, reporter)
+          options = Mzap::Options.new(api_key: "key")
+          Mzap.ajax_spider(target_file, apis: server.url, options: options, reporter: reporter)
         end
         requests = server.requests
         requests.size.should be > 0
@@ -39,8 +39,8 @@ describe Mzap do
       begin
         reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
         with_target_file(["https://target.test"]) do |target_file|
-          options = Mzap::Options.new("key", target_file)
-          Mzap.active_scan(target_file, server.url, options, reporter)
+          options = Mzap::Options.new(api_key: "key")
+          Mzap.active_scan(target_file, apis: server.url, options: options, reporter: reporter)
         end
         requests = server.requests
         requests.size.should be > 0
@@ -54,8 +54,8 @@ describe Mzap do
       server = TestServer.new
       begin
         reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
-        options = Mzap::Options.new("key", "")
-        Mzap.stop_spider(server.url, options, reporter)
+        options = Mzap::Options.new(api_key: "key")
+        Mzap.stop_spider(server.url, options: options, reporter: reporter)
         requests = server.requests
         requests.size.should be > 0
         requests.map(&.path).includes?(stop_path(Mzap::Client::SPIDER_STOP)).should be_true
@@ -68,8 +68,8 @@ describe Mzap do
       server = TestServer.new
       begin
         reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
-        options = Mzap::Options.new("key", "")
-        Mzap.stop_active_scan(server.url, options, reporter)
+        options = Mzap::Options.new(api_key: "key")
+        Mzap.stop_active_scan(server.url, options: options, reporter: reporter)
         requests = server.requests
         requests.size.should be > 0
         requests.map(&.path).includes?(stop_path(Mzap::Client::ASCAN_STOP)).should be_true
@@ -82,8 +82,8 @@ describe Mzap do
       server = TestServer.new
       begin
         reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
-        options = Mzap::Options.new("key", "")
-        Mzap.stop_ajax_spider(server.url, options, reporter)
+        options = Mzap::Options.new(api_key: "key")
+        Mzap.stop_ajax_spider(server.url, options: options, reporter: reporter)
         requests = server.requests
         requests.size.should be > 0
         requests.map(&.path).includes?(stop_path(Mzap::Client::AJAX_SPIDER_STOP)).should be_true

--- a/src/mzap.cr
+++ b/src/mzap.cr
@@ -9,27 +9,27 @@ require "./mzap/cli"
 module Mzap
   extend self
 
-  def spider(urls : String, apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
-    Client.spider(urls, apis, options, reporter)
+  def spider(urls : String, *, apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
+    Client.spider(urls, apis: apis, options: options, reporter: reporter)
   end
 
-  def ajax_spider(urls : String, apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
-    Client.ajax_spider(urls, apis, options, reporter)
+  def ajax_spider(urls : String, *, apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
+    Client.ajax_spider(urls, apis: apis, options: options, reporter: reporter)
   end
 
-  def active_scan(urls : String, apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
-    Client.active_scan(urls, apis, options, reporter)
+  def active_scan(urls : String, *, apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
+    Client.active_scan(urls, apis: apis, options: options, reporter: reporter)
   end
 
-  def stop_spider(apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
-    Client.stop_spider(apis, options, reporter)
+  def stop_spider(apis : String, *, options : Options, reporter : Reporter = Reporter.new) : Nil
+    Client.stop_spider(apis, options: options, reporter: reporter)
   end
 
-  def stop_active_scan(apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
-    Client.stop_active_scan(apis, options, reporter)
+  def stop_active_scan(apis : String, *, options : Options, reporter : Reporter = Reporter.new) : Nil
+    Client.stop_active_scan(apis, options: options, reporter: reporter)
   end
 
-  def stop_ajax_spider(apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
-    Client.stop_ajax_spider(apis, options, reporter)
+  def stop_ajax_spider(apis : String, *, options : Options, reporter : Reporter = Reporter.new) : Nil
+    Client.stop_ajax_spider(apis, options: options, reporter: reporter)
   end
 end

--- a/src/mzap/cli.cr
+++ b/src/mzap/cli.cr
@@ -199,7 +199,7 @@ module Mzap
         return 0
       end
 
-      command_args = args.size > 1 ? args[1..] : [] of String
+      command_args = args[1..]
       reporter = Reporter.new(stdout_io, stderr_io)
       report_format = options.report_format.downcase
 
@@ -229,13 +229,12 @@ module Mzap
       end
 
       zap_options = Options.new(
-        options.api_key,
-        options.urls,
-        options.wait || !report_format.empty?,
-        options.wait_interval_seconds,
-        options.wait_timeout_seconds,
-        report_format,
-        options.report_out
+        api_key: options.api_key,
+        wait_for_completion: options.wait || !report_format.empty?,
+        wait_interval_seconds: options.wait_interval_seconds,
+        wait_timeout_seconds: options.wait_timeout_seconds,
+        report_format: report_format,
+        report_out: options.report_out,
       )
 
       begin
@@ -250,9 +249,9 @@ module Mzap
             return 1
           end
           case command
-          when "spider"     then Client.spider(options.urls, options.apis, zap_options, reporter)
-          when "ajaxspider" then Client.ajax_spider(options.urls, options.apis, zap_options, reporter)
-          when "ascan"      then Client.active_scan(options.urls, options.apis, zap_options, reporter)
+          when "spider"     then Client.spider(options.urls, apis: options.apis, options: zap_options, reporter: reporter)
+          when "ajaxspider" then Client.ajax_spider(options.urls, apis: options.apis, options: zap_options, reporter: reporter)
+          when "ascan"      then Client.active_scan(options.urls, apis: options.apis, options: zap_options, reporter: reporter)
           end
         when "stop"
           if command_args.empty?
@@ -261,15 +260,15 @@ module Mzap
           else
             case command_args[0]
             when "spider"
-              Client.stop_spider(options.apis, zap_options, reporter)
+              Client.stop_spider(options.apis, options: zap_options, reporter: reporter)
             when "ascan"
-              Client.stop_active_scan(options.apis, zap_options, reporter)
+              Client.stop_active_scan(options.apis, options: zap_options, reporter: reporter)
             when "ajaxspider"
-              Client.stop_ajax_spider(options.apis, zap_options, reporter)
+              Client.stop_ajax_spider(options.apis, options: zap_options, reporter: reporter)
             when "all"
-              Client.stop_spider(options.apis, zap_options, reporter)
-              Client.stop_ajax_spider(options.apis, zap_options, reporter)
-              Client.stop_active_scan(options.apis, zap_options, reporter)
+              Client.stop_spider(options.apis, options: zap_options, reporter: reporter)
+              Client.stop_ajax_spider(options.apis, options: zap_options, reporter: reporter)
+              Client.stop_active_scan(options.apis, options: zap_options, reporter: reporter)
             else
               stdout_io.puts "Please input scanning mode for stop (spider/ascan/ajaxspider/all)"
               return 1

--- a/src/mzap/client.cr
+++ b/src/mzap/client.cr
@@ -31,27 +31,27 @@ module Mzap
     private record ScanJob, type : String, api_host : String, target : String, scan_id : String, zap_client : Zap::Client
     private record WaitPollResult, completed : Bool, failure_reason : String?
 
-    def spider(urls : String, apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
+    def spider(urls : String, *, apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
       run(urls, apis, "spider", options, reporter)
     end
 
-    def ajax_spider(urls : String, apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
+    def ajax_spider(urls : String, *, apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
       run(urls, apis, "ajax-spider", options, reporter)
     end
 
-    def active_scan(urls : String, apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
+    def active_scan(urls : String, *, apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
       run(urls, apis, "active-scan", options, reporter)
     end
 
-    def stop_spider(apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
+    def stop_spider(apis : String, *, options : Options, reporter : Reporter = Reporter.new) : Nil
       stop_all(apis, "spider", options, reporter)
     end
 
-    def stop_active_scan(apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
+    def stop_active_scan(apis : String, *, options : Options, reporter : Reporter = Reporter.new) : Nil
       stop_all(apis, "active-scan", options, reporter)
     end
 
-    def stop_ajax_spider(apis : String, options : Options, reporter : Reporter = Reporter.new) : Nil
+    def stop_ajax_spider(apis : String, *, options : Options, reporter : Reporter = Reporter.new) : Nil
       stop_all(apis, "ajax-spider", options, reporter)
     end
 
@@ -302,7 +302,7 @@ module Mzap
           break
         end
 
-        sleep options.wait_interval_seconds.seconds
+        sleep Math.max(options.wait_interval_seconds, 1).seconds
       end
 
       reporter.info("wait", "summary scan_completed=#{completed_scan_jobs}/#{total_scan_jobs} ajax_completed=#{completed_ajax_hosts}/#{total_ajax_hosts} poll_failures=#{poll_failures} timed_out=#{timed_out}")

--- a/src/mzap/options.cr
+++ b/src/mzap/options.cr
@@ -1,7 +1,6 @@
 module Mzap
   struct Options
     getter api_key : String
-    getter urls : String
     getter wait_for_completion : Bool
     getter wait_interval_seconds : Int32
     getter wait_timeout_seconds : Int32
@@ -9,8 +8,8 @@ module Mzap
     getter report_out : String
 
     def initialize(
+      *,
       @api_key : String = "",
-      @urls : String = "",
       @wait_for_completion : Bool = false,
       @wait_interval_seconds : Int32 = 2,
       @wait_timeout_seconds : Int32 = 0,


### PR DESCRIPTION
## Summary
- Remove unused `urls` field from `Options` struct (dead code — always passed as a separate parameter, never read by `Client`)
- Enforce named arguments via splat (`*`) on `Options.new` and all public API methods (`Mzap.*`, `Client.*`) to prevent positional arg mistakes
- Add minimum floor (1s) to `wait_interval_seconds` in `Client` polling loop to prevent tight busy-loop when called outside CLI validation
- Simplify `command_args` construction in CLI by removing redundant size check

## Test plan
- [x] All 172 existing specs pass with no changes to test logic (only call-site syntax updated)
- [ ] Verify no downstream consumers rely on positional argument ordering