### PR TITLE
chore: switch to official crystallang/crystal image

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           mkdir -p build
           # Use Crystal container to build static binary
-          docker run --rm -v $(pwd):/mzap -w /mzap --entrypoint="" 84codes/crystal:latest-debian-12 sh -c "
+          docker run --rm -v $(pwd):/mzap -w /mzap --entrypoint="" crystallang/crystal:1.19.1 sh -c "
             apt-get update && apt-get install -y libyaml-dev ca-certificates git curl &&
             shards install --production &&
             mkdir -p build &&

--- a/.github/workflows/release-deb.yml
+++ b/.github/workflows/release-deb.yml
@@ -35,7 +35,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
       - name: Build mzap Binary
         run: |
-          docker run --rm --platform linux/${{ matrix.arch }} -v $(pwd):/mzap -w /mzap --entrypoint="" 84codes/crystal:latest-debian-12 sh -c "
+          docker run --rm --platform linux/${{ matrix.arch }} -v $(pwd):/mzap -w /mzap --entrypoint="" crystallang/crystal:1.19.1 sh -c "
             apt-get update && apt-get install -y libyaml-dev ca-certificates git curl &&
             shards install --production &&
             /usr/bin/crystal build src/mzap_cli.cr -o mzap --release --no-debug --static


### PR DESCRIPTION
## Summary
- Crystal now provides [official Linux ARM64 builds](https://crystal-lang.org/2026/04/07/official-linux-arm64-builds/), so we no longer need the 84codes image for multi-arch support.
- Replaced `84codes/crystal:latest-debian-12` with `crystallang/crystal:1.19.1` in the release-binaries and release-deb workflows.

## Test plan
- [x] Static linux/arm64 build succeeds locally with the new image (produces statically linked aarch64 ELF)
- [ ] CI green