### PR TITLE
feat: clientspider, API import, policies & sitestree (modern ZAP 2.16/2.17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,15 @@ It dispatches targets across one or more ZAP API hosts, supports optional wait m
 
 ## Features
 
-- Multiple scan commands: `spider`, `ajaxspider`, `ascan`
+- Scan commands: `spider`, `ajaxspider`, `clientspider` (ZAP 2.16+), `ascan`, `pscan`
+- API definition import for `openapi`, `soap`, `graphql`, and `postman`
+- Sites Tree `export`/`prune` for ZAP 2.16+ differential/incremental scanning
+- Scan policy discovery (`policies`)
 - Multi-host dispatch with round-robin scheduling
 - Optional wait/poll mode with timeout support
-- Report export (`html`/`pdf`) with fallback behavior
-- Stop commands for `spider`, `ajaxspider`, `ascan`, or `all`
+- Report export (`html`/`pdf`/`json`/`md`/`sarif`) with fallback behavior
+- `--fail-on` risk gate for CI exit codes
+- Stop commands for `spider`, `ajaxspider`, `clientspider`, `ascan`, or `all`
 - Optional config loading from `$HOME/.config/mzap/config.toml` and legacy paths
 
 ## Requirements
@@ -52,26 +56,39 @@ Usage:
   mzap [command]
 
 Subcommands:
-  ajaxspider  Start Ajax Spider scans in ZAP
-  ascan       Start Active Scan jobs in ZAP
-  help        Show help for a command
-  spider      Start Spider scans in ZAP
-  stop        Stop running scans
-  version     Show mzap version
+  ajaxspider    Start Ajax Spider scans in ZAP
+  ascan         Start Active Scan jobs in ZAP
+  clientspider  Start Client Spider scans in ZAP (ZAP 2.16+)
+  help          Show help for a command
+  import        Import API definitions (openapi/soap/graphql/postman)
+  policies      List active-scan policies in ZAP
+  pscan         Wait for Passive Scan completion in ZAP
+  sitestree     Export or prune the ZAP Sites Tree (ZAP 2.16+)
+  spider        Start Spider scans in ZAP
+  stop          Stop running scans
+  version       Show mzap version
 
 Flags:
   --apikey string        ZAP API key (omit when API key auth is disabled)
   --apis string          Comma-separated ZAP API host URLs
                          e.g. --apis http://localhost:8090,http://192.168.0.4:8090 (default "http://localhost:8090")
   --config string        Config file path (TOML supported; default: $HOME/.config/mzap/config.toml)
-  --report-format        Report format after scan completion (html/pdf)
+  --context string       ZAP context file to import before scanning
+  --fail-on string       Fail with exit code 1 if alerts at or above risk level
+  --format string        API definition format for import (openapi/soap/graphql/postman)
+  --target-url string    Target/endpoint URL override for import
+  --policy string        Scan policy name for active scan
+  --report-format        Report format after scan completion (html/pdf/json/md/sarif)
   --report-out           Report output path (default: mzap-report-<timestamp>.<ext>)
+  --concurrency          Number of parallel scan dispatches (default 1)
   --wait                 Wait for initiated scans to complete
   --wait-interval        Poll interval in seconds while waiting (default 2)
   --wait-timeout         Wait timeout in seconds (default 0: no timeout)
   -h, --help             Show help for mzap
   --urls string          Path to URL list file (e.g. --urls hosts.txt)
 ```
+
+Run `mzap help <command>` for command-specific flags.
 
 ## Examples
 
@@ -82,9 +99,32 @@ mzap spider --urls samples/target.txt --apis http://localhost:8090,http://192.16
 # run scan, wait for completion, and generate an HTML report
 mzap spider --urls samples/target.txt --apis http://localhost:8090 --wait --report-format html --report-out reports/mzap.html
 
+# Client Spider (browser-based crawler, ZAP 2.16+; needs the Client Side Integration add-on)
+mzap clientspider --urls samples/target.txt --apis http://localhost:8090 --wait
+
+# import an OpenAPI definition, wait for passive scan, gate CI on high-risk alerts
+mzap import --format openapi --urls samples/specs.txt --target-url https://api.example.com \
+  --apis http://localhost:8090 --wait --report-format sarif --fail-on high
+
+# import API specs from stdin
+echo https://api.example.com/openapi.json | mzap import --format openapi --urls -
+
+# discover available scan policies (then use one with `ascan --policy`)
+mzap policies --apis http://localhost:8090
+
+# Sites Tree baseline for differential scanning (path resolved by the ZAP daemon)
+mzap sitestree export baseline.tree --apis http://localhost:8090
+mzap sitestree prune baseline.tree --apis http://localhost:8090
+
 # stop all running scan types
 mzap stop all --apis http://localhost:8090
 ```
+
+> **Importing APIs:** `mzap import` seeds ZAP's Sites Tree and lets passive
+> scanning run; to actively scan the imported endpoints afterwards, run
+> `mzap ascan` against the same target(s). For local files, paths in `--urls`
+> (and `--target-url`) are resolved by the ZAP daemon, so mount them into the
+> container when ZAP runs in Docker.
 
 ## Config
 

--- a/samples/specs.txt
+++ b/samples/specs.txt
@@ -1,0 +1,5 @@
+# API definition locations for `mzap import` (one per line).
+# Each line is a local file path or an http(s):// URL.
+# Use --format to select the importer: openapi | soap | graphql | postman.
+https://raw.githubusercontent.com/OWASP/www-project-zap/master/openapi.json
+# /work/specs/my-api.yaml

--- a/shard.lock
+++ b/shard.lock
@@ -6,5 +6,5 @@ shards:
 
   zap:
     git: https://github.com/hahwul/zap.cr.git
-    version: 0.1.0
+    version: 0.2.0
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: mzap
-version: 2.1.1
+version: 2.2.0
 description: Multi-target ZAP scanning CLI tool with multi-host dispatch and report generation
 
 authors:
@@ -15,6 +15,7 @@ targets:
 dependencies:
   zap:
     github: hahwul/zap.cr
+    version: ~> 0.2.0
   sarif:
     github: hahwul/sarif.cr
 

--- a/spec/mzap_cli_commands_spec.cr
+++ b/spec/mzap_cli_commands_spec.cr
@@ -161,6 +161,7 @@ describe Mzap::CLI do
         [
           stop_path(Mzap::Client::SPIDER_STOP),
           stop_path(Mzap::Client::AJAX_SPIDER_STOP),
+          stop_path(Mzap::Client::CLIENT_SPIDER_STOP),
           stop_path(Mzap::Client::ASCAN_STOP),
         ]
       )

--- a/spec/mzap_cli_options_spec.cr
+++ b/spec/mzap_cli_options_spec.cr
@@ -7,7 +7,7 @@ describe Mzap::CLI do
 
     code = Mzap::CLI.run(["stop", "invalid"], stdout_io, stderr_io)
     code.should eq(1)
-    stdout_io.to_s.includes?("spider/ascan/ajaxspider/all").should be_true
+    stdout_io.to_s.includes?("spider/ascan/ajaxspider/clientspider/all").should be_true
   end
 
   it "returns error for unknown command" do

--- a/spec/mzap_client_clientspider_spec.cr
+++ b/spec/mzap_client_clientspider_spec.cr
@@ -1,0 +1,79 @@
+require "./spec_helper"
+
+describe Mzap do
+  it "runs client spider scan endpoint after accessing the url" do
+    server = TestServer.new(->(context : HTTP::Server::Context) do
+      context.response.status_code = 200
+      if context.request.path == Mzap::Client::CLIENT_SPIDER_API
+        context.response.print(%({"scan":"3"}))
+      else
+        context.response.print(%({"ok":"true"}))
+      end
+    end)
+
+    begin
+      reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
+      with_target_file(["https://spa.test"]) do |target_file|
+        options = Mzap::Options.new
+        Mzap.client_spider(target_file, apis: server.url, options: options, reporter: reporter)
+      end
+
+      requests = server.requests
+      requests.size.should eq(2)
+      requests[0].path.should eq(Mzap::Client::ACCESS_API)
+      requests[1].path.should eq(Mzap::Client::CLIENT_SPIDER_API)
+      HTTP::Params.parse(requests[1].query || "")["url"].should eq("https://spa.test")
+    ensure
+      server.close
+    end
+  end
+
+  it "waits for client spider completion using percentage status" do
+    polls = 0
+    server = TestServer.new(->(context : HTTP::Server::Context) do
+      context.response.status_code = 200
+      case context.request.path
+      when Mzap::Client::CLIENT_SPIDER_API
+        context.response.print(%({"scan":"5"}))
+      when Mzap::Client::CLIENT_SPIDER_STAT
+        polls += 1
+        context.response.print(polls >= 2 ? %({"status":"100"}) : %({"status":"40"}))
+      else
+        context.response.print(%({"ok":"true"}))
+      end
+    end)
+
+    begin
+      stdout_io = IO::Memory.new
+      reporter = Mzap::Reporter.new(stdout_io, IO::Memory.new)
+      with_target_file(["https://spa.test"]) do |target_file|
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 1)
+        Mzap.client_spider(target_file, apis: server.url, options: options, reporter: reporter)
+      end
+
+      status_request = server.requests.find { |r| r.path == Mzap::Client::CLIENT_SPIDER_STAT }
+      status_request.should_not be_nil
+      HTTP::Params.parse(status_request.not_nil!.query || "")["scanId"].should eq("5")
+      stdout_io.to_s.includes?("complete").should be_true
+    ensure
+      server.close
+    end
+  end
+
+  it "sends client spider stop request" do
+    server = TestServer.new
+
+    begin
+      reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
+      options = Mzap::Options.new(api_key: "stop-key")
+      Mzap.stop_client_spider(server.url, options: options, reporter: reporter)
+
+      requests = server.requests
+      requests.size.should eq(1)
+      requests[0].path.should eq(Mzap::Client::CLIENT_SPIDER_STOP)
+      requests[0].api_key.should eq("stop-key")
+    ensure
+      server.close
+    end
+  end
+end

--- a/spec/mzap_client_import_spec.cr
+++ b/spec/mzap_client_import_spec.cr
@@ -1,0 +1,178 @@
+require "./spec_helper"
+
+describe Mzap do
+  it "imports an openapi spec from a url via the importUrl endpoint" do
+    server = TestServer.new
+
+    begin
+      reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
+      with_target_file(["https://api.example.com/openapi.json"]) do |spec_file|
+        options = Mzap::Options.new(api_key: "imp-key")
+        Mzap.import_api(spec_file, format: "openapi", target_url: "https://api.example.com", apis: server.url, options: options, reporter: reporter)
+      end
+
+      requests = server.requests
+      requests.size.should eq(1)
+      requests[0].path.should eq(Mzap::Client::OPENAPI_IMPORT_URL_API)
+      params = HTTP::Params.parse(requests[0].query || "")
+      params["url"].should eq("https://api.example.com/openapi.json")
+      params["hostOverride"].should eq("https://api.example.com")
+      requests[0].api_key.should eq("imp-key")
+    ensure
+      server.close
+    end
+  end
+
+  it "imports an openapi spec from a local file via the importFile endpoint" do
+    server = TestServer.new
+
+    begin
+      reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
+      with_target_file(["/specs/api.yaml"]) do |spec_file|
+        options = Mzap::Options.new
+        Mzap.import_api(spec_file, format: "openapi", target_url: "https://api.example.com", apis: server.url, options: options, reporter: reporter)
+      end
+
+      requests = server.requests
+      requests.size.should eq(1)
+      requests[0].path.should eq(Mzap::Client::OPENAPI_IMPORT_FILE_API)
+      params = HTTP::Params.parse(requests[0].query || "")
+      params["file"].should eq("/specs/api.yaml")
+      params["target"].should eq("https://api.example.com")
+    ensure
+      server.close
+    end
+  end
+
+  it "routes each format to its import endpoint" do
+    cases = {
+      "soap"    => {"https://svc.example.com?wsdl", Mzap::Client::SOAP_IMPORT_URL_API},
+      "graphql" => {"https://api.example.com/graphql", Mzap::Client::GRAPHQL_IMPORT_URL_API},
+      "postman" => {"https://api.example.com/collection.json", Mzap::Client::POSTMAN_IMPORT_URL_API},
+    }
+
+    cases.each do |format, (spec, expected_path)|
+      server = TestServer.new
+      begin
+        reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
+        with_target_file([spec]) do |spec_file|
+          options = Mzap::Options.new
+          Mzap.import_api(spec_file, format: format, apis: server.url, options: options, reporter: reporter)
+        end
+
+        requests = server.requests
+        requests.size.should eq(1)
+        requests[0].path.should eq(expected_path)
+        HTTP::Params.parse(requests[0].query || "")["url"].should eq(spec)
+      ensure
+        server.close
+      end
+    end
+  end
+
+  it "distributes specs across hosts round-robin" do
+    server1 = TestServer.new
+    server2 = TestServer.new
+
+    begin
+      reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
+      with_target_file(["https://a.example/openapi.json", "https://b.example/openapi.json", "https://c.example/openapi.json"]) do |spec_file|
+        options = Mzap::Options.new
+        Mzap.import_api(spec_file, format: "openapi", apis: "#{server1.url},#{server2.url}", options: options, reporter: reporter)
+      end
+
+      server1.requests.size.should eq(2)
+      server2.requests.size.should eq(1)
+    ensure
+      server1.close
+      server2.close
+    end
+  end
+
+  it "waits for passive scan to settle after import when wait is enabled" do
+    pscan_calls = 0
+    server = TestServer.new(->(context : HTTP::Server::Context) do
+      context.response.status_code = 200
+      case context.request.path
+      when Mzap::Client::PSCAN_RECORDS_TO_SCAN
+        pscan_calls += 1
+        context.response.print(pscan_calls >= 2 ? %({"recordsToScan":"0"}) : %({"recordsToScan":"3"}))
+      else
+        context.response.print(%({"ok":"true"}))
+      end
+    end)
+
+    begin
+      stdout_io = IO::Memory.new
+      reporter = Mzap::Reporter.new(stdout_io, IO::Memory.new)
+      with_target_file(["https://api.example.com/openapi.json"]) do |spec_file|
+        options = Mzap::Options.new(wait_for_completion: true, wait_interval_seconds: 0, wait_timeout_seconds: 5)
+        Mzap.import_api(spec_file, format: "openapi", apis: server.url, options: options, reporter: reporter)
+      end
+
+      pscan_calls.should eq(2)
+      stdout_io.to_s.includes?("completed=1/1").should be_true
+    ensure
+      server.close
+    end
+  end
+
+  it "reports a summary and skips when the spec list is empty" do
+    server = TestServer.new
+
+    begin
+      stdout_io = IO::Memory.new
+      stderr_io = IO::Memory.new
+      reporter = Mzap::Reporter.new(stdout_io, stderr_io)
+      with_target_file(["", "  # comment only"]) do |spec_file|
+        options = Mzap::Options.new
+        Mzap.import_api(spec_file, format: "openapi", apis: server.url, options: options, reporter: reporter)
+      end
+
+      server.requests.should be_empty
+      stderr_io.to_s.includes?("no specs loaded from file").should be_true
+    ensure
+      server.close
+    end
+  end
+
+  it "runs import via CLI and requires --format" do
+    stdout_io = IO::Memory.new
+    stderr_io = IO::Memory.new
+
+    with_target_file(["https://api.example.com/openapi.json"]) do |spec_file|
+      code = Mzap::CLI.run(["import", "--urls", spec_file], stdout_io, stderr_io)
+      code.should eq(1)
+      stderr_io.to_s.includes?("--format is required").should be_true
+    end
+  end
+
+  it "rejects an unknown import format via CLI" do
+    stdout_io = IO::Memory.new
+    stderr_io = IO::Memory.new
+
+    with_target_file(["https://api.example.com/openapi.json"]) do |spec_file|
+      code = Mzap::CLI.run(["import", "--format", "wsdlx", "--urls", spec_file], stdout_io, stderr_io)
+      code.should eq(1)
+      stderr_io.to_s.includes?("--format supports only").should be_true
+    end
+  end
+
+  it "runs a successful import via CLI" do
+    server = TestServer.new
+
+    begin
+      stdout_io = IO::Memory.new
+      stderr_io = IO::Memory.new
+      with_target_file(["https://api.example.com/openapi.json"]) do |spec_file|
+        code = Mzap::CLI.run(["import", "--format", "openapi", "--urls", spec_file, "--apis", server.url], stdout_io, stderr_io)
+        code.should eq(0)
+      end
+
+      paths = server.requests.map(&.path)
+      paths.includes?(Mzap::Client::OPENAPI_IMPORT_URL_API).should be_true
+    ensure
+      server.close
+    end
+  end
+end

--- a/spec/mzap_client_inspect_spec.cr
+++ b/spec/mzap_client_inspect_spec.cr
@@ -1,0 +1,138 @@
+require "./spec_helper"
+
+describe Mzap do
+  it "lists scan policy names per host" do
+    server = TestServer.new(->(context : HTTP::Server::Context) do
+      context.response.status_code = 200
+      if context.request.path == Mzap::Client::SCAN_POLICY_NAMES_API
+        context.response.print(%({"scanPolicyNames":["Default Policy","API-Minimal-Scan"]}))
+      else
+        context.response.print(%({"ok":"true"}))
+      end
+    end)
+
+    begin
+      stdout_io = IO::Memory.new
+      reporter = Mzap::Reporter.new(stdout_io, IO::Memory.new)
+      Mzap.list_policies(server.url, options: Mzap::Options.new, reporter: reporter)
+
+      stdout = stdout_io.to_s
+      stdout.includes?("scan policies: Default Policy, API-Minimal-Scan").should be_true
+    ensure
+      server.close
+    end
+  end
+
+  it "reports scanner counts for a named policy" do
+    server = TestServer.new(->(context : HTTP::Server::Context) do
+      context.response.status_code = 200
+      if context.request.path == Mzap::Client::ASCAN_SCANNERS_API
+        context.response.print(%({"scanners":[{"id":"1","enabled":"true"},{"id":"2","enabled":"false"}]}))
+      else
+        context.response.print(%({"ok":"true"}))
+      end
+    end)
+
+    begin
+      stdout_io = IO::Memory.new
+      reporter = Mzap::Reporter.new(stdout_io, IO::Memory.new)
+      Mzap.list_policies(server.url, policy: "API-Minimal-Scan", options: Mzap::Options.new, reporter: reporter)
+
+      requests = server.requests
+      requests[0].path.should eq(Mzap::Client::ASCAN_SCANNERS_API)
+      HTTP::Params.parse(requests[0].query || "")["scanPolicyName"].should eq("API-Minimal-Scan")
+      stdout_io.to_s.includes?("2 scanner(s), 1 enabled").should be_true
+    ensure
+      server.close
+    end
+  end
+
+  it "exports the sites tree with the given path" do
+    server = TestServer.new
+
+    begin
+      reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
+      Mzap.export_sites_tree(server.url, file_path: "baseline.tree", options: Mzap::Options.new(api_key: "k"), reporter: reporter)
+
+      requests = server.requests
+      requests.size.should eq(1)
+      requests[0].path.should eq(Mzap::Client::EXPORT_SITES_TREE_API)
+      HTTP::Params.parse(requests[0].query || "")["filePath"].should eq("baseline.tree")
+      requests[0].api_key.should eq("k")
+    ensure
+      server.close
+    end
+  end
+
+  it "prunes the sites tree with the given path" do
+    server = TestServer.new
+
+    begin
+      reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
+      Mzap.prune_sites_tree(server.url, file_path: "baseline.tree", options: Mzap::Options.new, reporter: reporter)
+
+      requests = server.requests
+      requests.size.should eq(1)
+      requests[0].path.should eq(Mzap::Client::PRUNE_SITES_TREE_API)
+      HTTP::Params.parse(requests[0].query || "")["filePath"].should eq("baseline.tree")
+    ensure
+      server.close
+    end
+  end
+
+  it "namespaces sites tree paths per host across multiple hosts" do
+    server1 = TestServer.new
+    server2 = TestServer.new
+
+    begin
+      reporter = Mzap::Reporter.new(IO::Memory.new, IO::Memory.new)
+      Mzap.export_sites_tree("#{server1.url},#{server2.url}", file_path: "baseline.tree", options: Mzap::Options.new, reporter: reporter)
+
+      path1 = HTTP::Params.parse(server1.requests[0].query || "")["filePath"]
+      path2 = HTTP::Params.parse(server2.requests[0].query || "")["filePath"]
+      path1.should_not eq(path2)
+      path1.ends_with?(".tree").should be_true
+      path2.ends_with?(".tree").should be_true
+    ensure
+      server1.close
+      server2.close
+    end
+  end
+
+  it "runs policies and sitestree via CLI" do
+    server = TestServer.new(->(context : HTTP::Server::Context) do
+      context.response.status_code = 200
+      if context.request.path == Mzap::Client::SCAN_POLICY_NAMES_API
+        context.response.print(%({"scanPolicyNames":["Default Policy"]}))
+      else
+        context.response.print(%({"ok":"true"}))
+      end
+    end)
+
+    begin
+      stdout_io = IO::Memory.new
+      stderr_io = IO::Memory.new
+
+      code = Mzap::CLI.run(["policies", "--apis", server.url], stdout_io, stderr_io)
+      code.should eq(0)
+
+      code = Mzap::CLI.run(["sitestree", "export", "baseline.tree", "--apis", server.url], stdout_io, stderr_io)
+      code.should eq(0)
+
+      paths = server.requests.map(&.path)
+      paths.includes?(Mzap::Client::SCAN_POLICY_NAMES_API).should be_true
+      paths.includes?(Mzap::Client::EXPORT_SITES_TREE_API).should be_true
+    ensure
+      server.close
+    end
+  end
+
+  it "rejects an invalid sitestree action via CLI" do
+    stdout_io = IO::Memory.new
+    stderr_io = IO::Memory.new
+
+    code = Mzap::CLI.run(["sitestree", "bogus", "x.tree"], stdout_io, stderr_io)
+    code.should eq(1)
+    stdout_io.to_s.includes?("export/prune").should be_true
+  end
+end

--- a/src/mzap.cr
+++ b/src/mzap.cr
@@ -21,8 +21,16 @@ module Mzap
     Client.active_scan(urls, apis: apis, options: options, reporter: reporter)
   end
 
+  def client_spider(urls : String, *, apis : String, options : Options, reporter : Reporter = Reporter.new) : Bool
+    Client.client_spider(urls, apis: apis, options: options, reporter: reporter)
+  end
+
   def passive_scan(apis : String, *, options : Options, reporter : Reporter = Reporter.new) : Bool
     Client.passive_scan(apis, options: options, reporter: reporter)
+  end
+
+  def import_api(urls : String, *, format : String, target_url : String = "", apis : String, options : Options, reporter : Reporter = Reporter.new) : Bool
+    Client.import_api(urls, format: format, target_url: target_url, apis: apis, options: options, reporter: reporter)
   end
 
   def stop_spider(apis : String, *, options : Options, reporter : Reporter = Reporter.new) : Nil
@@ -35,5 +43,21 @@ module Mzap
 
   def stop_ajax_spider(apis : String, *, options : Options, reporter : Reporter = Reporter.new) : Nil
     Client.stop_ajax_spider(apis, options: options, reporter: reporter)
+  end
+
+  def stop_client_spider(apis : String, *, options : Options, reporter : Reporter = Reporter.new) : Nil
+    Client.stop_client_spider(apis, options: options, reporter: reporter)
+  end
+
+  def list_policies(apis : String, *, policy : String = "", options : Options, reporter : Reporter = Reporter.new) : Nil
+    Client.list_policies(apis, policy: policy, options: options, reporter: reporter)
+  end
+
+  def export_sites_tree(apis : String, *, file_path : String, options : Options, reporter : Reporter = Reporter.new) : Nil
+    Client.export_sites_tree(apis, file_path: file_path, options: options, reporter: reporter)
+  end
+
+  def prune_sites_tree(apis : String, *, file_path : String, options : Options, reporter : Reporter = Reporter.new) : Nil
+    Client.prune_sites_tree(apis, file_path: file_path, options: options, reporter: reporter)
   end
 end

--- a/src/mzap/cli.cr
+++ b/src/mzap/cli.cr
@@ -18,6 +18,8 @@ module Mzap
       property fail_on : String = ""
       property retry_count : Int32 = 0
       property retry_delay_seconds : Int32 = 5
+      property format : String = ""
+      property target_url : String = ""
       property help : Bool = false
     end
 
@@ -39,6 +41,8 @@ module Mzap
       property fail_on : Bool = false
       property retry_count : Bool = false
       property retry_delay_seconds : Bool = false
+      property format : Bool = false
+      property target_url : Bool = false
     end
 
     HELP_TEXT = <<-TEXT
@@ -46,13 +50,17 @@ module Mzap
       mzap [command]
 
     Subcommands:
-      ajaxspider  Start Ajax Spider scans in ZAP
-      ascan       Start Active Scan jobs in ZAP
-      help        Show help for a command
-      pscan       Wait for Passive Scan completion in ZAP
-      spider      Start Spider scans in ZAP
-      stop        Stop running scans
-      version     Show mzap version
+      ajaxspider    Start Ajax Spider scans in ZAP
+      ascan         Start Active Scan jobs in ZAP
+      clientspider  Start Client Spider scans in ZAP (ZAP 2.16+)
+      help          Show help for a command
+      import        Import API definitions (openapi/soap/graphql/postman)
+      policies      List active-scan policies in ZAP
+      pscan         Wait for Passive Scan completion in ZAP
+      sitestree     Export or prune the ZAP Sites Tree (ZAP 2.16+)
+      spider        Start Spider scans in ZAP
+      stop          Stop running scans
+      version       Show mzap version
 
     Flags:
       --apikey string        ZAP API key (omit when API key auth is disabled)
@@ -114,6 +122,22 @@ module Mzap
     #{SCAN_FLAGS_TEXT}
     TEXT
 
+    HELP_CLIENTSPIDER = <<-TEXT
+    Start Client Spider scans in ZAP
+
+    The Client Spider is the modern, browser-based crawler introduced in ZAP 2.16.
+    It requires ZAP >= 2.16 with the "Client Side Integration" add-on installed.
+
+    Usage:
+      mzap clientspider --urls <file> [flags]
+
+    Examples:
+      mzap clientspider --urls targets.txt --apis http://localhost:8090
+      mzap clientspider --urls targets.txt --apis http://localhost:8090 --wait --report-format html
+
+    #{SCAN_FLAGS_TEXT}
+    TEXT
+
     HELP_ASCAN = <<-TEXT
     Start Active Scan jobs in ZAP
 
@@ -127,6 +151,38 @@ module Mzap
 
     #{SCAN_FLAGS_TEXT}
       --policy string        ZAP scan policy name for active scan
+    TEXT
+
+    HELP_IMPORT = <<-TEXT
+    Import API definitions into ZAP
+
+    Seeds ZAP's Sites Tree from API definitions so the endpoints can be passively
+    scanned and reported, or actively scanned afterwards with `mzap ascan`.
+    Each line in --urls is a spec location: a local file path or an http(s):// URL.
+
+    Usage:
+      mzap import --format <openapi|soap|graphql|postman> --urls <file> [flags]
+
+    Examples:
+      mzap import --format openapi --urls specs.txt --apis http://localhost:8090
+      mzap import --format openapi --urls specs.txt --target-url https://api.example.com --wait --report-format sarif --fail-on high
+      echo https://api.example.com/openapi.json | mzap import --format openapi --urls -
+
+    Flags:
+      --format string        API definition format: openapi, soap, graphql, or postman
+      --urls string          Path to spec list file (file paths or http(s):// URLs, one per line)
+      --target-url string    Target/endpoint URL override (openapi target & host override; graphql endpoint)
+      --apis string          Comma-separated ZAP API host URLs (default "http://localhost:8090")
+      --apikey string        ZAP API key (omit when API key auth is disabled)
+      --config string        Config file path (default: $HOME/.config/mzap/config.toml)
+      --context string       ZAP context file to import before importing specs
+      --wait                 Wait for passive scanning to settle after import
+      --wait-interval        Poll interval in seconds while waiting (default 2)
+      --wait-timeout         Wait timeout in seconds (default 0: no timeout)
+      --report-format        Report format after import completion (html/pdf/json/md/sarif)
+      --report-out           Report output path (default: mzap-report-<timestamp>.<ext>)
+      --fail-on string       Fail with exit code 1 if alerts at or above risk level
+      -h, --help             Show help
     TEXT
 
     PSCAN_FLAGS_TEXT = <<-TEXT
@@ -154,6 +210,49 @@ module Mzap
     #{PSCAN_FLAGS_TEXT}
     TEXT
 
+    HELP_POLICIES = <<-TEXT
+    List active-scan policies in ZAP
+
+    Discovers the scan policy names available on each host (useful for the ascan
+    --policy flag). Pass --policy <name> to report scanner counts for that policy.
+
+    Usage:
+      mzap policies [--policy <name>] [flags]
+
+    Examples:
+      mzap policies --apis http://localhost:8090
+      mzap policies --policy "API-Minimal-Scan" --apis http://localhost:8090
+
+    Flags:
+      --apis string          Comma-separated ZAP API host URLs (default "http://localhost:8090")
+      --apikey string        ZAP API key (omit when API key auth is disabled)
+      --policy string        Report scanner counts for this policy instead of listing names
+      --config string        Config file path (default: $HOME/.config/mzap/config.toml)
+      -h, --help             Show help
+    TEXT
+
+    HELP_SITESTREE = <<-TEXT
+    Export or prune the ZAP Sites Tree
+
+    Uses ZAP 2.16+ text-based Sites Tree files to support differential/incremental
+    scanning in CI. The file path is resolved by the ZAP daemon, so on remote or
+    Docker ZAP the file is written/read on the ZAP host, not the mzap host.
+
+    Usage:
+      mzap sitestree export <path> [flags]
+      mzap sitestree prune <path> [flags]
+
+    Examples:
+      mzap sitestree export baseline.tree --apis http://localhost:8090
+      mzap sitestree prune baseline.tree --apis http://localhost:8090
+
+    Flags:
+      --apis string          Comma-separated ZAP API host URLs (default "http://localhost:8090")
+      --apikey string        ZAP API key (omit when API key auth is disabled)
+      --config string        Config file path (default: $HOME/.config/mzap/config.toml)
+      -h, --help             Show help
+    TEXT
+
     HELP_STOP = <<-TEXT
     Stop running scans
 
@@ -163,6 +262,7 @@ module Mzap
     Types:
       spider       Stop all Spider scans
       ajaxspider   Stop Ajax Spider scans
+      clientspider Stop Client Spider scans
       ascan        Stop all Active Scans
       all          Stop all scan types
 
@@ -185,20 +285,25 @@ module Mzap
     TEXT
 
     SUBCOMMAND_HELP = {
-      "spider"     => HELP_SPIDER,
-      "ajaxspider" => HELP_AJAXSPIDER,
-      "ascan"      => HELP_ASCAN,
-      "pscan"      => HELP_PSCAN,
-      "stop"       => HELP_STOP,
-      "version"    => HELP_VERSION,
+      "spider"       => HELP_SPIDER,
+      "ajaxspider"   => HELP_AJAXSPIDER,
+      "clientspider" => HELP_CLIENTSPIDER,
+      "ascan"        => HELP_ASCAN,
+      "import"       => HELP_IMPORT,
+      "policies"     => HELP_POLICIES,
+      "sitestree"    => HELP_SITESTREE,
+      "pscan"        => HELP_PSCAN,
+      "stop"         => HELP_STOP,
+      "version"      => HELP_VERSION,
     }
 
-    STRING_FLAGS = {"--config", "--apikey", "--urls", "--apis", "--report-format", "--report-out", "--policy", "--context", "--fail-on"}
+    STRING_FLAGS = {"--config", "--apikey", "--urls", "--apis", "--report-format", "--report-out", "--policy", "--context", "--fail-on", "--format", "--target-url"}
     INT_FLAGS    = {"--wait-interval", "--wait-timeout", "--concurrency", "--retry", "--retry-delay"}
 
     # Accepted enumerated values, shared between validation and help text intent.
     FAIL_ON_LEVELS = {"informational", "low", "medium", "high"}
     REPORT_FORMATS = {"html", "pdf", "json", "md", "sarif"}
+    IMPORT_FORMATS = {"openapi", "soap", "graphql", "postman"}
 
     def self.run(argv : Array(String) = ARGV, stdout_io : IO = STDOUT, stderr_io : IO = STDERR) : Int32
       Banner.show(stderr_io)
@@ -210,7 +315,7 @@ module Mzap
         return 1
       end
 
-      scan_commands = {"spider", "ajaxspider", "ascan", "pscan"}
+      scan_commands = {"spider", "ajaxspider", "ascan", "clientspider", "pscan", "import"}
       command = args.empty? ? "" : args[0]
       scan_command = scan_commands.includes?(command)
 
@@ -260,7 +365,18 @@ module Mzap
 
       begin
         case command
-        when "spider", "ajaxspider", "ascan"
+        when "spider", "ajaxspider", "ascan", "clientspider", "import"
+          import_format = options.format.downcase
+          if command == "import"
+            if import_format.empty?
+              stderr_io.puts "--format is required for import (openapi/soap/graphql/postman)"
+              return 1
+            end
+            unless IMPORT_FORMATS.includes?(import_format)
+              stderr_io.puts "--format supports only openapi, soap, graphql, or postman"
+              return 1
+            end
+          end
           if options.urls == "-"
             stdin_temp_file = File.tempname("mzap-stdin")
             File.write(stdin_temp_file, STDIN.gets_to_end)
@@ -275,15 +391,34 @@ module Mzap
             return 1
           end
           fail_on_triggered = case command
-                              when "spider"     then Client.spider(options.urls, apis: options.apis, options: zap_options, reporter: reporter)
-                              when "ajaxspider" then Client.ajax_spider(options.urls, apis: options.apis, options: zap_options, reporter: reporter)
-                              when "ascan"      then Client.active_scan(options.urls, apis: options.apis, options: zap_options, reporter: reporter)
-                              else                   false
+                              when "spider"       then Client.spider(options.urls, apis: options.apis, options: zap_options, reporter: reporter)
+                              when "ajaxspider"   then Client.ajax_spider(options.urls, apis: options.apis, options: zap_options, reporter: reporter)
+                              when "ascan"        then Client.active_scan(options.urls, apis: options.apis, options: zap_options, reporter: reporter)
+                              when "clientspider" then Client.client_spider(options.urls, apis: options.apis, options: zap_options, reporter: reporter)
+                              when "import"       then Client.import_api(options.urls, format: import_format, target_url: options.target_url, apis: options.apis, options: zap_options, reporter: reporter)
+                              else                     false
                               end
           return 1 if fail_on_triggered
         when "pscan"
           fail_on_triggered = Client.passive_scan(options.apis, options: zap_options, reporter: reporter)
           return 1 if fail_on_triggered
+        when "policies"
+          Client.list_policies(options.apis, policy: options.policy, options: zap_options, reporter: reporter)
+        when "sitestree"
+          action = command_args[0]?
+          unless action && {"export", "prune"}.includes?(action)
+            stdout_io.puts "Please input sitestree action (export/prune)"
+            return 1
+          end
+          tree_path = command_args[1]?
+          if tree_path.nil? || tree_path.empty?
+            stderr_io.puts "Please provide a file path: mzap sitestree #{action} <path>"
+            return 1
+          end
+          case action
+          when "export" then Client.export_sites_tree(options.apis, file_path: tree_path, options: zap_options, reporter: reporter)
+          when "prune"  then Client.prune_sites_tree(options.apis, file_path: tree_path, options: zap_options, reporter: reporter)
+          end
         when "stop"
           if command_args.empty?
             stdout_io.puts "Please input scanning mode for stop"
@@ -296,12 +431,15 @@ module Mzap
               Client.stop_active_scan(options.apis, options: zap_options, reporter: reporter)
             when "ajaxspider"
               Client.stop_ajax_spider(options.apis, options: zap_options, reporter: reporter)
+            when "clientspider"
+              Client.stop_client_spider(options.apis, options: zap_options, reporter: reporter)
             when "all"
               Client.stop_spider(options.apis, options: zap_options, reporter: reporter)
               Client.stop_ajax_spider(options.apis, options: zap_options, reporter: reporter)
+              Client.stop_client_spider(options.apis, options: zap_options, reporter: reporter)
               Client.stop_active_scan(options.apis, options: zap_options, reporter: reporter)
             else
-              stdout_io.puts "Please input scanning mode for stop (spider/ascan/ajaxspider/all)"
+              stdout_io.puts "Please input scanning mode for stop (spider/ascan/ajaxspider/clientspider/all)"
               return 1
             end
           end
@@ -379,7 +517,7 @@ module Mzap
       end
 
       if (options.wait || !report_format.empty?) && !scan_command
-        return "--wait and report options are only available for spider/ajaxspider/ascan/pscan"
+        return "--wait and report options are only available for spider/ajaxspider/ascan/clientspider/pscan/import"
       end
 
       nil
@@ -483,6 +621,8 @@ module Mzap
       apply_config_field(updated, provided_options, config_options, fail_on, fail_on, fail_on)
       apply_config_field(updated, provided_options, config_options, retry_count, retry_count, retry_count)
       apply_config_field(updated, provided_options, config_options, retry_delay_seconds, retry_delay_seconds, retry_delay_seconds)
+      apply_config_field(updated, provided_options, config_options, format, format, format)
+      apply_config_field(updated, provided_options, config_options, target_url, target_url, target_url)
 
       updated
     end
@@ -513,6 +653,8 @@ module Mzap
       apply_env_string(updated, provided_options.fail_on, "MZAP_FAIL_ON") { |v| updated.fail_on = v }
       apply_env_int(updated, provided_options.retry_count, "MZAP_RETRY") { |v| updated.retry_count = v }
       apply_env_int(updated, provided_options.retry_delay_seconds, "MZAP_RETRY_DELAY") { |v| updated.retry_delay_seconds = v }
+      apply_env_string(updated, provided_options.format, "MZAP_FORMAT") { |v| updated.format = v }
+      apply_env_string(updated, provided_options.target_url, "MZAP_TARGET_URL") { |v| updated.target_url = v }
 
       updated
     end
@@ -620,6 +762,12 @@ module Mzap
       when "--fail-on"
         options.fail_on = value
         provided.fail_on = true
+      when "--format"
+        options.format = value
+        provided.format = true
+      when "--target-url"
+        options.target_url = value
+        provided.target_url = true
       else
         raise ArgumentError.new("Unknown option: #{flag}")
       end

--- a/src/mzap/client.cr
+++ b/src/mzap/client.cr
@@ -6,19 +6,22 @@ module Mzap
   module Client
     extend self
 
-    ACCESS_API      = "/JSON/core/action/accessUrl/"
-    SPIDER_API      = "/JSON/spider/action/scan/"
-    ASCAN_API       = "/JSON/ascan/action/scan/"
-    AJAX_SPIDER_API = "/JSON/ajaxSpider/action/scan/"
-    SPIDER_STATUS   = "/JSON/spider/view/status/"
-    ASCAN_STATUS    = "/JSON/ascan/view/status/"
-    AJAX_STATUS     = "/JSON/ajaxSpider/view/status/"
+    ACCESS_API         = "/JSON/core/action/accessUrl/"
+    SPIDER_API         = "/JSON/spider/action/scan/"
+    ASCAN_API          = "/JSON/ascan/action/scan/"
+    AJAX_SPIDER_API    = "/JSON/ajaxSpider/action/scan/"
+    CLIENT_SPIDER_API  = "/JSON/clientSpider/action/scan/"
+    SPIDER_STATUS      = "/JSON/spider/view/status/"
+    ASCAN_STATUS       = "/JSON/ascan/view/status/"
+    AJAX_STATUS        = "/JSON/ajaxSpider/view/status/"
+    CLIENT_SPIDER_STAT = "/JSON/clientSpider/view/status/"
 
     PSCAN_RECORDS_TO_SCAN = "/JSON/pscan/view/recordsToScan/"
 
-    SPIDER_STOP      = "/JSON/spider/action/stopAllScans/"
-    ASCAN_STOP       = "/JSON/ascan/action/stopAllScans/"
-    AJAX_SPIDER_STOP = "/JSON/ajaxSpider/action/stop/"
+    SPIDER_STOP        = "/JSON/spider/action/stopAllScans/"
+    ASCAN_STOP         = "/JSON/ascan/action/stopAllScans/"
+    AJAX_SPIDER_STOP   = "/JSON/ajaxSpider/action/stop/"
+    CLIENT_SPIDER_STOP = "/JSON/clientSpider/action/stop/"
 
     REPORT_GENERATE_API = "/JSON/reports/action/generate/"
     HTML_REPORT_API     = "/OTHER/core/other/htmlreport/"
@@ -55,36 +58,19 @@ module Mzap
       run(urls, apis, "active-scan", options, reporter)
     end
 
+    # Client Spider is the modern, browser-based crawler introduced in ZAP 2.16
+    # (the "client" add-on). Requires ZAP >= 2.16 with the Client Side Integration
+    # add-on installed; otherwise the scan dispatch surfaces a clear API error.
+    def client_spider(urls : String, *, apis : String, options : Options, reporter : Reporter = Reporter.new) : Bool
+      run(urls, apis, "client-spider", options, reporter)
+    end
+
     def passive_scan(apis : String, *, options : Options, reporter : Reporter = Reporter.new) : Bool
       reporter.info("passive-scan", "start")
 
       api_hosts = normalize_api_hosts(apis)
       with_zap_clients(api_hosts, options) do |clients|
-        pending = api_hosts.uniq.map { |host| {host, clients[host]} }
-        reporter.info("passive-scan", "waiting for #{pending.size} host(s)")
-
-        started_at = Time.utc
-        poll_failures = 0
-        completed_hosts = 0
-        last_poll_failure = {} of String => String
-
-        timed_out = run_poll_loop(started_at, options) do
-          pending.reject! do |(api_host, zap_client)|
-            outcome = poll_pscan_status(api_host, zap_client, reporter, last_poll_failure)
-            completed_hosts += 1 if outcome.completed
-            poll_failures += 1 if outcome.poll_failed
-            outcome.completed
-          end
-          pending.empty?
-        end
-
-        if timed_out
-          pending.each do |(api_host, _)|
-            reporter.warn("passive-scan", "timeout", api_host)
-          end
-        end
-
-        reporter.info("passive-scan", "summary completed=#{completed_hosts}/#{api_hosts.uniq.size} poll_failures=#{poll_failures} timed_out=#{timed_out}")
+        wait_for_passive_scan(api_hosts, clients, options, reporter)
 
         print_alert_summary(clients, reporter)
 
@@ -113,6 +99,10 @@ module Mzap
       stop_all(apis, "ajax-spider", options, reporter)
     end
 
+    def stop_client_spider(apis : String, *, options : Options, reporter : Reporter = Reporter.new) : Nil
+      stop_all(apis, "client-spider", options, reporter)
+    end
+
     def run(urls : String, apis : String, scan_type : String, options : Options, reporter : Reporter = Reporter.new) : Bool
       reporter.info(scan_type, "start")
 
@@ -121,19 +111,7 @@ module Mzap
         return false
       end
 
-      targets = [] of String
-      seen = Set(String).new
-      duplicates_removed = 0
-      File.each_line(urls) do |line|
-        value = line.strip
-        next if value.empty?
-        next if value.starts_with?('#')
-        if seen.add?(value)
-          targets << value
-        else
-          duplicates_removed += 1
-        end
-      end
+      targets, duplicates_removed = read_targets(urls)
 
       if targets.empty? && duplicates_removed == 0
         reporter.warn(scan_type, "no targets loaded from file", urls)
@@ -308,7 +286,7 @@ module Mzap
     ) : Nil
       return unless options.wait_enabled?
       case scan_type
-      when "spider", "active-scan"
+      when "spider", "active-scan", "client-spider"
         scan_id = extract_scan_id(result)
         if scan_id
           scan_jobs << ScanJob.new(scan_type, api_host, target, scan_id, zap_client)
@@ -368,6 +346,8 @@ module Mzap
         zap_client.ascan.scan(url: target, scan_policy_name: policy)
       when "ajax-spider"
         zap_client.ajax_spider.scan(url: target)
+      when "client-spider"
+        zap_client.client_spider.scan(url: target)
       else
         raise Zap::Error.new("Unknown scan type: #{scan_type}")
       end
@@ -417,6 +397,26 @@ module Mzap
       end
     end
 
+    # Reads a target/spec list file, stripping blanks and `#` comments and removing
+    # duplicates while preserving order. Returns the unique entries plus the count
+    # of duplicates dropped, so callers can warn appropriately.
+    private def read_targets(path : String) : {Array(String), Int32}
+      targets = [] of String
+      seen = Set(String).new
+      duplicates_removed = 0
+      File.each_line(path) do |line|
+        value = line.strip
+        next if value.empty?
+        next if value.starts_with?('#')
+        if seen.add?(value)
+          targets << value
+        else
+          duplicates_removed += 1
+        end
+      end
+      {targets, duplicates_removed}
+    end
+
     private def normalize_api_hosts(apis : String) : Array(String)
       hosts = apis.split(",").map { |h| h.strip.rstrip('/') }.reject(&.empty?)
       if hosts.empty?
@@ -441,6 +441,8 @@ module Mzap
               zap_client.ascan.stop_all
             when "ajax-spider"
               zap_client.ajax_spider.stop
+            when "client-spider"
+              zap_client.client_spider.stop
             end
             success_count += 1
             reporter.info(scan_type, "stopped", api_host)
@@ -459,3 +461,5 @@ end
 require "./client/alerts"
 require "./client/wait"
 require "./client/reports"
+require "./client/imports"
+require "./client/inspect"

--- a/src/mzap/client/imports.cr
+++ b/src/mzap/client/imports.cr
@@ -1,0 +1,104 @@
+require "zap"
+require "set"
+
+module Mzap
+  # API-definition import concern for Mzap::Client: seeds ZAP's Sites Tree from
+  # OpenAPI/SOAP/GraphQL/Postman definitions so the endpoints can be passively
+  # scanned, reported, or actively scanned afterwards. Reuses the shared
+  # passive-settle + report + fail-on tail from the rest of the client.
+  module Client
+    extend self
+
+    OPENAPI_IMPORT_FILE_API = "/JSON/openapi/action/importFile/"
+    OPENAPI_IMPORT_URL_API  = "/JSON/openapi/action/importUrl/"
+    GRAPHQL_IMPORT_FILE_API = "/JSON/graphql/action/importFile/"
+    GRAPHQL_IMPORT_URL_API  = "/JSON/graphql/action/importUrl/"
+    SOAP_IMPORT_FILE_API    = "/JSON/soap/action/importFile/"
+    SOAP_IMPORT_URL_API     = "/JSON/soap/action/importUrl/"
+    POSTMAN_IMPORT_FILE_API = "/JSON/postman/action/importFile/"
+    POSTMAN_IMPORT_URL_API  = "/JSON/postman/action/importUrl/"
+
+    # Imports each spec from the `urls` list file (one location per line; a local
+    # file path or an http(s):// URL) into every API host, round-robin. After
+    # import, reuses the passive-settle + report + fail-on pipeline. Returns true
+    # only when --fail-on is set and the gate is tripped.
+    def import_api(urls : String, *, format : String, target_url : String = "", apis : String, options : Options, reporter : Reporter = Reporter.new) : Bool
+      reporter.info("import", "start (#{format})")
+
+      unless File.exists?(urls)
+        reporter.warn("import", "spec list file not found", urls)
+        return false
+      end
+
+      specs, duplicates_removed = read_targets(urls)
+      if specs.empty? && duplicates_removed == 0
+        reporter.warn("import", "no specs loaded from file", urls)
+        return false
+      end
+      if duplicates_removed > 0
+        reporter.warn("import", "removed #{duplicates_removed} duplicate spec(s)")
+      end
+
+      api_hosts = normalize_api_hosts(apis)
+      with_zap_clients(api_hosts, options) do |clients|
+        if !options.context.empty?
+          import_context(clients, options.context, reporter)
+        end
+
+        success = 0
+        errors = 0
+        specs.each_with_index do |spec, index|
+          api_host = api_hosts[index % api_hosts.size]
+          zap_client = clients[api_host]
+          begin
+            with_retry(options.retry_count, options.retry_delay_seconds, reporter, "import", "import", api_host, spec) do
+              dispatch_import(zap_client, format, spec, target_url)
+            end
+            success += 1
+            reporter.info("import", "imported", api_host, spec)
+          rescue ex : Exception
+            errors += 1
+            reporter.warn("import", "error #{format_error(ex)}", api_host, spec)
+          end
+        end
+
+        reporter.info("import", "summary specs=#{specs.size} success=#{success} errors=#{errors}")
+
+        if options.wait_enabled?
+          wait_for_passive_scan(api_hosts, clients, options, reporter)
+          print_alert_summary(clients, reporter)
+        end
+
+        if options.report_enabled?
+          report_targets = Hash(String, Set(String)).new { |hash, key| hash[key] = Set(String).new }
+          api_hosts.uniq.each { |host| report_targets[host] = Set(String).new }
+          generate_reports(report_targets, clients, options, reporter)
+        end
+
+        if !options.fail_on.empty?
+          return check_fail_on(clients, options, reporter)
+        end
+      end
+      false
+    end
+
+    # Routes a single spec to the right ZAP import endpoint based on `format` and
+    # whether the spec is a URL or a local file. `target_url` overrides the
+    # imported target (OpenAPI target/host override; GraphQL endpoint).
+    private def dispatch_import(zap_client : Zap::Client, format : String, spec : String, target_url : String) : JSON::Any
+      is_url = spec.starts_with?("http://") || spec.starts_with?("https://")
+      case format
+      when "openapi"
+        is_url ? zap_client.openapi.import_url(spec, host_override: target_url) : zap_client.openapi.import_file(spec, target: target_url)
+      when "graphql"
+        is_url ? zap_client.graphql.import_url(spec, endpoint: target_url) : zap_client.graphql.import_file(spec, endpoint: target_url)
+      when "soap"
+        is_url ? zap_client.soap.import_url(spec) : zap_client.soap.import_file(spec)
+      when "postman"
+        is_url ? zap_client.postman.import_url(spec) : zap_client.postman.import_file(spec)
+      else
+        raise Zap::Error.new("Unknown import format: #{format}")
+      end
+    end
+  end
+end

--- a/src/mzap/client/inspect.cr
+++ b/src/mzap/client/inspect.cr
@@ -1,0 +1,115 @@
+require "zap"
+
+module Mzap
+  # Inspection / maintenance concern for Mzap::Client: discovery of active-scan
+  # policies (so the --policy flag is usable) and Sites Tree export/prune for
+  # ZAP 2.16+ differential/incremental scanning in CI.
+  module Client
+    extend self
+
+    SCAN_POLICY_NAMES_API = "/JSON/ascan/view/scanPolicyNames/"
+    ASCAN_SCANNERS_API    = "/JSON/ascan/view/scanners/"
+    EXPORT_SITES_TREE_API = "/JSON/exim/action/exportSitesTree/"
+    PRUNE_SITES_TREE_API  = "/JSON/exim/action/pruneSitesTree/"
+
+    # Lists active-scan policy names per host. When `policy` is given, reports the
+    # scanner counts for that policy instead, so users can tune it.
+    def list_policies(apis : String, *, policy : String = "", options : Options, reporter : Reporter = Reporter.new) : Nil
+      api_hosts = normalize_api_hosts(apis)
+      with_zap_clients(api_hosts, options) do |clients|
+        api_hosts.each do |api_host|
+          zap_client = clients[api_host]
+          begin
+            if policy.empty?
+              names = extract_named_array(zap_client.ascan.scan_policy_names, "scanPolicyNames")
+              if names.empty?
+                reporter.info("policies", "no scan policies found", api_host)
+              else
+                reporter.info("policies", "scan policies: #{names.join(", ")}", api_host)
+              end
+            else
+              scanners = zap_client.ascan.scanners(scan_policy_name: policy).as_h?.try(&.["scanners"]?).try(&.as_a?) || [] of JSON::Any
+              enabled = scanners.count { |s| s.as_h?.try(&.["enabled"]?).try(&.as_s?) == "true" }
+              reporter.info("policies", "policy '#{policy}': #{scanners.size} scanner(s), #{enabled} enabled", api_host)
+            end
+          rescue ex : Exception
+            reporter.warn("policies", "error #{format_error(ex)}", api_host)
+          end
+        end
+      end
+    end
+
+    # Exports each host's Sites Tree to a file. NOTE: the path is resolved by the
+    # ZAP daemon (not mzap), so on remote/Docker ZAP the file lands on the ZAP host.
+    def export_sites_tree(apis : String, *, file_path : String, options : Options, reporter : Reporter = Reporter.new) : Nil
+      run_sites_tree(apis, "export", file_path, options, reporter)
+    end
+
+    # Prunes each host's Sites Tree using a previously exported file (daemon-side
+    # path, see export_sites_tree).
+    def prune_sites_tree(apis : String, *, file_path : String, options : Options, reporter : Reporter = Reporter.new) : Nil
+      run_sites_tree(apis, "prune", file_path, options, reporter)
+    end
+
+    private def run_sites_tree(apis : String, action : String, file_path : String, options : Options, reporter : Reporter) : Nil
+      api_hosts = normalize_api_hosts(apis)
+      paths = resolve_sites_tree_paths(api_hosts, file_path)
+      success = 0
+      failure = 0
+
+      with_zap_clients(api_hosts, options) do |clients|
+        api_hosts.uniq.each do |api_host|
+          zap_client = clients[api_host]
+          host_path = paths[api_host]
+          begin
+            case action
+            when "export" then zap_client.exim.export_sites_tree(host_path)
+            when "prune"  then zap_client.exim.prune_sites_tree(host_path)
+            end
+            success += 1
+            reporter.info("sitestree", "#{action} requested (ZAP host path: #{host_path})", api_host)
+          rescue ex : Exception
+            failure += 1
+            reporter.warn("sitestree", "#{action} error #{format_error(ex)}", api_host)
+          end
+        end
+      end
+
+      reporter.info("sitestree", "summary action=#{action} success=#{success} failed=#{failure}")
+    end
+
+    # Namespaces the tree file path per host when more than one distinct host is
+    # targeted, mirroring how reports are split, so shared-filesystem hosts do not
+    # collide.
+    private def resolve_sites_tree_paths(api_hosts : Array(String), file_path : String) : Hash(String, String)
+      paths = {} of String => String
+      uniq = api_hosts.uniq
+      if uniq.size <= 1
+        uniq.each { |host| paths[host] = file_path }
+        return paths
+      end
+
+      dir = File.dirname(file_path)
+      ext = File.extname(file_path)
+      stem = File.basename(file_path, ext)
+      counts = Hash(String, Int32).new(0)
+      uniq.each do |api_host|
+        base = sanitize_host(api_host)
+        counts[base] += 1
+        suffix = counts[base]
+        safe = suffix == 1 ? base : "#{base}-#{suffix}"
+        name = "#{stem}-#{safe}#{ext}"
+        paths[api_host] = dir == "." ? name : File.join(dir, name)
+      end
+      paths
+    end
+
+    private def extract_named_array(result : JSON::Any, key : String) : Array(String)
+      hash = result.as_h?
+      return [] of String unless hash
+      arr = hash[key]?.try(&.as_a?)
+      return [] of String unless arr
+      arr.compact_map(&.as_s?)
+    end
+  end
+end

--- a/src/mzap/client/wait.cr
+++ b/src/mzap/client/wait.cr
@@ -57,6 +57,43 @@ module Mzap
       reporter.info("wait", "summary scan_completed=#{completed_scan_jobs}/#{total_scan_jobs} ajax_completed=#{completed_ajax_hosts}/#{total_ajax_hosts} poll_failures=#{poll_failures} timed_out=#{timed_out}")
     end
 
+    # Polls passive-scan completion (recordsToScan -> 0) across all hosts until each
+    # settles or the wait timeout elapses. Shared by the `pscan` command and the
+    # post-import settle step. Progress is logged under `category`.
+    private def wait_for_passive_scan(
+      api_hosts : Array(String),
+      clients : Hash(String, Zap::Client),
+      options : Options,
+      reporter : Reporter,
+      category : String = "passive-scan",
+    ) : Nil
+      pending = api_hosts.uniq.map { |host| {host, clients[host]} }
+      reporter.info(category, "waiting for #{pending.size} host(s)")
+
+      started_at = Time.utc
+      poll_failures = 0
+      completed_hosts = 0
+      last_poll_failure = {} of String => String
+
+      timed_out = run_poll_loop(started_at, options) do
+        pending.reject! do |(api_host, zap_client)|
+          outcome = poll_pscan_status(api_host, zap_client, reporter, last_poll_failure)
+          completed_hosts += 1 if outcome.completed
+          poll_failures += 1 if outcome.poll_failed
+          outcome.completed
+        end
+        pending.empty?
+      end
+
+      if timed_out
+        pending.each do |(api_host, _)|
+          reporter.warn(category, "timeout", api_host)
+        end
+      end
+
+      reporter.info(category, "summary completed=#{completed_hosts}/#{api_hosts.uniq.size} poll_failures=#{poll_failures} timed_out=#{timed_out}")
+    end
+
     private def poll_scan_job(
       job : ScanJob,
       reporter : Reporter,
@@ -181,6 +218,9 @@ module Mzap
                when "active-scan"
                  scan_id = job.scan_id.to_i? || -1
                  job.zap_client.ascan.status(scan_id)
+               when "client-spider"
+                 scan_id = job.scan_id.to_i? || -1
+                 job.zap_client.client_spider.status(scan_id)
                else
                  return WaitPollResult.new(false, "(unknown scan type)")
                end

--- a/src/mzap/config.cr
+++ b/src/mzap/config.cr
@@ -27,6 +27,8 @@ module Mzap
       property fail_on : String?
       property retry_count : Int32?
       property retry_delay_seconds : Int32?
+      property format : String?
+      property target_url : String?
     end
 
     def load_options(config_path : String) : FileOptions
@@ -145,6 +147,10 @@ module Mzap
         options.retry_count = parse_toml_int(raw_value, key, path, line_number)
       when "retry_delay", "retry_delay_seconds"
         options.retry_delay_seconds = parse_toml_int(raw_value, key, path, line_number)
+      when "format", "import_format"
+        options.format = parse_toml_string(raw_value, key, path, line_number)
+      when "target_url", "target"
+        options.target_url = parse_toml_string(raw_value, key, path, line_number)
       end
     end
 

--- a/src/mzap/version.cr
+++ b/src/mzap/version.cr
@@ -1,3 +1,3 @@
 module Mzap
-  VERSION = "v2.1.1"
+  VERSION = "v2.2.0"
 end


### PR DESCRIPTION
## Summary

Closes the main capability gaps between `mzap` and modern OWASP ZAP (latest stable
**2.17.0**). Most were CLI-exposure gaps — the `zap.cr` library already wrapped the
endpoints. Requires **zap.cr 0.2.0** (hahwul/zap.cr#14), which adds the
ClientSpider/Postman parameters these commands need; `shard.yml`/`shard.lock` are
pinned to `~> 0.2.0`.

## New commands

| Command | Description |
|---|---|
| `clientspider` / `stop clientspider` | ZAP 2.16 browser-based crawler (DOM-aware). Integrated into the existing scan → percentage-wait → stop pipeline. Needs ZAP ≥ 2.16 + the Client Side Integration add-on. |
| `import --format openapi\|soap\|graphql\|postman` | Seed ZAP's Sites Tree from API definitions (file paths or URLs in `--urls`, `-` for stdin). Reuses passive-settle + `--report-format` + `--fail-on`. `--target-url` overrides the OpenAPI target / GraphQL endpoint. |
| `policies` | List active-scan policy names per host (makes `ascan --policy` discoverable); `--policy <name>` reports scanner counts. |
| `sitestree export\|prune <path>` | ZAP 2.16 text Sites Tree for differential/incremental CI scans. Path is resolved by the ZAP daemon. |

## Implementation notes

- New `--format` / `--target-url` flags wired consistently through CLI parsing,
  `Config::FileOptions` (TOML) and env (`MZAP_FORMAT` / `MZAP_TARGET_URL`).
- Extracted a shared `wait_for_passive_scan` helper (used by `pscan` and `import`)
  and a `read_targets` helper (used by scans and `import`); `passive_scan` refactored
  onto it with identical log output.
- `client/imports.cr` and `client/inspect.cr` added as focused concerns.

## Testing

- 247 specs pass (added 19 across clientspider / import / inspect), built against the
  published `zap` 0.2.0.
- `crystal tool format --check src/ spec/` clean; adversarial diff review found no
  correctness bugs.

## Deferred (follow-ups)

Automation Framework runner (`mzap run plan.yaml`), authenticated scanning as-user
(`--user`/`--context-name`), and 2.17 "Systemic"-alert awareness in `--fail-on`.