### PR TITLE
docs(changelog): note portable macOS release tarballs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- macOS release binaries are now shipped as portable `.tar.gz` archives with bundled OpenSSL libraries, instead of a bare executable linked against Homebrew `openssl@1.1` that failed to launch on clean machines (`dyld: libssl.1.1.dylib not found`).
+
 ## v2.1.1
 
 ### Fixed


### PR DESCRIPTION
Document the macOS release binary portability fix in CHANGELOG.