### PR TITLE
ci(snap): publish on workflow_dispatch for security rebuilds

### DIFF
--- a/.github/workflows/publish-snapcraft.yml
+++ b/.github/workflows/publish-snapcraft.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v6
       - uses: canonical/action-build@v1
         id: build
-      - if: github.event_name == 'release'
+      - if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
         uses: snapcore/action-publish@master
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}


### PR DESCRIPTION
## Why

The Snap Store's automated USN scanner flags this snap when a staged deb
(e.g. `libxml2`, USN-8456-1) receives a security update. The fix is
simply to rebuild the snap so it pulls the patched package.

But the publish step ran only on `release` events:

```yaml
- if: github.event_name == 'release'
```

So a manual `workflow_dispatch` run **built** the snap but never
**published** it — there was no way to do a security rebuild without
cutting a full release.

## What

```diff
- - if: github.event_name == 'release'
+ - if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
```

This matches the existing `owasp-noir/noir` workflow. After merging, a
security rebuild is just: run the **Snapcraft Publish** workflow
manually → builds and republishes to `stable` with the patched libxml2.